### PR TITLE
Simplify calls to setup.py

### DIFF
--- a/python-oslo-messaging.spec
+++ b/python-oslo-messaging.spec
@@ -31,7 +31,6 @@ Requires:   python-eventlet >= 0.13.0
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 BuildRequires: python-pbr
-BuildRequires: python-d2to1
 
 %description
 The Oslo project intends to produce a python library containing

--- a/python-oslo-messaging.spec
+++ b/python-oslo-messaging.spec
@@ -66,20 +66,11 @@ Documentation for the oslo.messaging library.
 %prep
 %setup -q -n %{sname}-%{upstream_version}
 
-# Remove bundled egg-info
-rm -rf %{sname}.egg-info
-# let RPM handle deps
-sed -i '/setup_requires/d; /install_requires/d; /dependency_links/d' setup.py
-
-# Remove the requirements file so that pbr hooks don't add it
-# to distutils requires_dist config
-rm -rf {test-,}requirements.txt
-
 %build
-%{__python} setup.py build
+SKIP_PIP_INSTALL=1 %{__python} setup.py build
 
 %install
-%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+SKIP_PIP_INSTALL=1 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
 
 # Delete tests
 rm -fr %{buildroot}%{python_sitelib}/tests


### PR DESCRIPTION
Removing the egg-info file is a bug - and it's not required by fedora
policy. There was an unclear statement on the python packaging policy
wiki that made it seem so, but it was really saying to not use upstream
eggs. egg-info dirs are important.

Additionally, it is not necessary to edit the setup.py file or to remove
the requirements files - there is an env var which turns off all code
paths related to those activities.
